### PR TITLE
docstrings added to iquick script

### DIFF
--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -277,8 +277,8 @@ def extract_raw_arrays(data, mmbgs: Iterable[MultiMainBlockGeometry]):
                 block.tag,
                 as_strided(
                     data[mmbg.offset + block.offset :],
-                    (mmbg.count, block.size),
-                    (mmbg.step if mmbg.count > 1 else 1, 1),
+                    shape=(mmbg.count, block.size),
+                    strides=(mmbg.step if mmbg.count > 1 else 1, 1),
                     subok=True,
                     writeable=False,
                 ),

--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -156,7 +156,7 @@ def get_geometry(data):
     ValueError: If the main tag cannot be found in the data, indicating that the data may not be a PDS file.
     """
     o = 0
-    main_tag, main_size = get_tag_size(data)
+    main_tag, main_size = get_tag_size(data[:8])
 
     if (
         len(data) < main_size + 8

--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -10,14 +10,14 @@ from numpy.lib.stride_tricks import as_strided
 @dataclass
 class SingleSubBlockGeometry:
     """
-    Representation of a single sub-block, as explained in
+    Representation of a single sub-block geometry, as explained in
     Meteorological Ka-Band Cloud Radar MIRA35 Manual, section 2.3.1
     'Definition of chunk common structure', e.g. for a chunk in an
     Embedded chain type 2 (see section 2.3.3.2).
 
     Attributes:
         tag (str): The tag/signature representing the chunk type.
-        offset (int): Pointer to start of sub-block's data block.
+        offset (int): Pointer to start of sub-block's data block relative to the enclosing main block.
         size (int): The size of the sub-block's data block (bytes).
     """
     tag: str
@@ -28,21 +28,19 @@ class SingleSubBlockGeometry:
 @dataclass
 class SingleMainBlockGeometry:
     """
-    Representation of a single main block as list of
+    Representation of a single main block geometry as list of
     SingleSubBlockGeometry instances with some overarching metadata.
 
     This represents one 'main chunk' as in Meteorological Ka-Band Cloud Radar
     MIRA35 Manual, section 2.3.2 'File structure', and should be chunk as in
-    section 2.3.3 'Main chunk structure', that is either for DSP parameters
-    as in 'Embedded chain type 1; PPar' or for data frame as in
-    'Embedded chain type 2; Data chain'
+    section 2.3.3 'Main chunk structure'.
 
     The sub-blocks of a SingleMainBlockGeometry correspond to each of the blocks
     in the embedded chunk chain which composes the main chunk.
 
     Attributes:
         tag (str): The tag / frame header describing the data in the sub-blocks.
-        offset (int): Pointer to start of the main block's sub-blocks.
+        offset (int): Pointer to start of the main block's sub-blocks, relative to the file.
         size (int): The size of the main block's sub-blocks (bytes).
         subblocks (List[SingleSubBlockGeometry]): A list of sub-blocks within
                                                   the main block.
@@ -267,8 +265,7 @@ def extract_raw_arrays(data, mmbgs: Iterable[MultiMainBlockGeometry]):
         tuple: A tuple containing:
             - mmbg.tag: The tag/signature of the main block.
             - block.tag: The tag/signature of the subblock.
-            - ndarray: A view of the data array corresponding to the subblock,
-                       created using numpy's as_strided function.
+            - ndarray: A view of the data array corresponding to the subblock.
     """
     for mmbg in mmbgs:
         for block in mmbg.subblocks:
@@ -371,10 +368,6 @@ def read_pds(filename, postprocess=True):
     only functioning with geometry of pds files and decoders for IQ data of
     Ka radar currently operational on HALO (last checked: 13th Septermber 2024).
 
-    Optimisation uses NumPy library memory-mapped array to avoid reading
-    entirety of large binary file into main memory from disc when only (small)
-    segment is desired.
-
     Parameters:
     filename (str): The path to the file containing the IQ data.
     postprocess (bool): Whether to apply post-processing to the dataset. Default is True.
@@ -402,13 +395,6 @@ def decode_time(ds):
     """
     Replaces 'Tm' and 'time_milli' variables in dataset 'ds' with decoded time.
 
-    The function calculates the time by adding:
-    - A base time of "1970-01-01"
-    - 'Tm' multiplied by 1 second (expressed as 1,000,000,000 ns)
-    - 'time_milli' multiplied by 0.001 (expressed as ns)
-
-    The resulting time is then assigned to a new 'time' variable in the dataset.
-
     Parameters:
     ds (xarray.Dataset): The input dataset containing 'Tm' and 'time_milli'
                          variables.
@@ -431,10 +417,6 @@ def postprocess_iq(ds):
 
 
 def main():
-    '''
-    Use an argument parser with positional argument for the filename to read IQ
-    data from the file called 'filename' and decode the time.
-    '''
     import argparse
 
     parser = argparse.ArgumentParser()

--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -348,7 +348,7 @@ def decode_iq(rawdata):
         )
     }
 
-
+#TODO(ALL): move decoders to seperate file
 decoders = {
     """
     Decoders for IQ data as in Meteorological Ka-Band Cloud Radar MIRA35 Manual,

--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -353,7 +353,7 @@ decoders = {
     """
     Decoders for IQ data as in Meteorological Ka-Band Cloud Radar MIRA35 Manual,
     section 2.3.3.2 'Embedded chain type 2; Data chain'. Note these decoders are
-    specific to the HAMP radar currently in operation on HALO.
+    specific to the Ka radar currently in operation on HALO.
     (last checked: 13th Septermber 2024).
     """
     b"SRVI": decode_srvi,
@@ -365,9 +365,11 @@ decoders = {
 }
 
 
-def read_iq(filename, postprocess=True):
+def read_pds(filename, postprocess=True):
     """
-    Converts IQ data from a file called 'filename', into an xarray Dataset.
+    Converts data from a file called 'filename', into an xarray Dataset. Currently
+    only functioning with geometry of pds files and decoders for IQ data of
+    Ka radar currently operational on HALO (last checked: 13th Septermber 2024).
 
     Optimisation uses NumPy library memory-mapped array to avoid reading
     entirety of large binary file into main memory from disc when only (small)
@@ -439,7 +441,7 @@ def main():
     parser.add_argument("filename")
     args = parser.parse_args()
 
-    print(read_iq(args.filename).pipe(decode_time))
+    print(read_pds(args.filename).pipe(decode_time))
 
 
 if __name__ == "__main__":

--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -383,7 +383,7 @@ def read_pds(filename, postprocess=True):
     xarray.Dataset: The IQ data dataset.
     """
     data = np.memmap(filename, mode='r')
-    raw_arrays = list(extract_raw_arrays(data, get_geometry(data)))
+    raw_arrays = extract_raw_arrays(data, get_geometry(data))
     # TODO(ALL) add failure if same decoder key repeats (temporary) 
     ds = xr.Dataset(
         {

--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -382,7 +382,7 @@ def read_pds(filename, postprocess=True):
     Returns:
     xarray.Dataset: The IQ data dataset.
     """
-    data = np.memmap(filename)
+    data = np.memmap(filename, mode='r')
     raw_arrays = list(extract_raw_arrays(data, get_geometry(data)))
     # TODO(ALL) add failure if same decoder key repeats (temporary) 
     ds = xr.Dataset(

--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -9,6 +9,17 @@ from numpy.lib.stride_tricks import as_strided
 
 @dataclass
 class SingleSubBlockGeometry:
+    """
+    Representation of a single sub-block, as explained in
+    Meteorological Ka-Band Cloud Radar MIRA35 Manual, section 2.3.1
+    'Definition of chunk common structure', e.g. for a chunk in an
+    Embedded chain type 2 (see section 2.3.3.2).
+
+    Attributes:
+        tag (str): The tag/signature representing the chunk type.
+        offset (int): Pointer to start of sub-block's data block.
+        size (int): The size of the sub-block's data block (bytes).
+    """
     tag: str
     offset: int
     size: int
@@ -16,6 +27,26 @@ class SingleSubBlockGeometry:
 
 @dataclass
 class SingleMainBlockGeometry:
+    """
+    Representation of a single main block as list of
+    SingleSubBlockGeometry instances with some overarching metadata.
+
+    This represents one 'main chunk' as in Meteorological Ka-Band Cloud Radar
+    MIRA35 Manual, section 2.3.2 'File structure', and should be chunk as in
+    section 2.3.3 'Main chunk structure', that is either for DSP parameters
+    as in 'Embedded chain type 1; PPar' or for data frame as in
+    'Embedded chain type 2; Data chain'
+
+    The sub-blocks of a SingleMainBlockGeometry correspond to each of the blocks
+    in the embedded chunk chain which composes the main chunk.
+
+    Attributes:
+        tag (str): The tag / frame header describing the data in the sub-blocks.
+        offset (int): Pointer to start of the main block's sub-blocks.
+        size (int): The size of the main block's sub-blocks (bytes).
+        subblocks (List[SingleSubBlockGeometry]): A list of sub-blocks within
+                                                  the main block.
+    """
     tag: str
     offset: int
     size: int
@@ -24,6 +55,25 @@ class SingleMainBlockGeometry:
 
 @dataclass
 class MultiMainBlockGeometry:
+    """
+    Representation of multiple main blocks as list of SingleSubBlockGeometry
+    instances with some overarching metadata. This can be multiple 'main chunks'
+    as in Meteorological Ka-Band Cloud Radar MIRA35 Manual, section 2.3.2
+    'File structure'.
+    
+    Allows for 'count' number of SingleMainBlockGeometry instances to be
+    combined, assuming they are similar enough (e.g. same subblocks, same offset,
+    same tag etc.). (See compact_geometry function.)
+
+    Attributes:
+        tag (str): The tag/signature describing the main blocks.
+        offset (int): Pointer to the start of the first main block.
+        count (int): The number of SingleMainBlockGeometry instances
+                     combined to make the MultiMainBlockGeometry instance.
+        step (Optional[int]): The distance between each SingleMainBlockGeometry
+                              instance, required if count > 1.
+        subblocks (List[SingleSubBlockGeometry]): The sub-blocks in each main block.
+    """
     tag: str
     offset: int
     count: int
@@ -32,6 +82,19 @@ class MultiMainBlockGeometry:
 
 
 def main_ofs(mainblock):
+    # blocktype and blocksize assumed to by 4 bytes long
+    """
+    Returns the list of SingleSubBlockGeometry instances for a main block of
+    data, as in Meteorological Ka-Band Cloud Radar MIRA35 Manual, section 2.3.2
+    'File structure'.
+
+    Args:
+        mainblock (bytes): The main block data ('main chunk' in manual).
+
+    Returns:
+        list: A list of SingleSubBlockGeometry instances, each representing a sub-block
+              within the main block.
+    """
     o = 0
     ofs = []
     while o + 8 < len(mainblock):
@@ -43,10 +106,55 @@ def main_ofs(mainblock):
 
 
 def get_tag_size(data):
+    """
+    Extracts the tag (also known as signature) and the pointer for size
+    from 'data' assuming layout as in Meteorological Ka-Band Cloud Radar
+    MIRA35 Manual, section 2.3.1 'Definition of chunk common structure'
+    where the tag is the first 4 bytes of data and the pointer is the
+    next 4 bytes.
+
+    Args:
+        data (bytes): The data assumed to conform with Meteorological Ka-Band
+                      Cloud Radar MIRA35 Manual, section 2.3.1 'Definition of
+                      chunk common structure'
+
+    Returns:
+        Tuple[bytes, int]: The tag and the pointer for size.
+    """
     return bytes(data[:4]), data[4:8].view("<i4")[0]
 
 
 def get_geometry(data):
+    """
+    Interprets and returns the geometry of the 'data' assuming it is a
+    memmap of a PDS file (or an open PDS file) for radar IQ data with structure
+    as in Meteorological Ka-Band Cloud Radar MIRA35 Manual, section 2.3.2
+    'File structure'.
+
+    First attempt will read the main tag and size from first 8 bytes
+    of the data. If the data length is insufficient, or the main tag is not
+    found by attempting to return to the start of the file from main_size+8,
+    it shifts the offset by 1024 bytes (to skip file header) and tries again.
+    If the main tag is still not found, it raises a ValueError.
+
+    If get_tag_size is sucessful, the function defines a generator
+    `main_blocks` that iterates through the data, yielding
+    `SingleMainBlockGeometry` instances for each block (i.e. for each main chunk
+    as defined in section 2.3.2)
+
+    The function returns a list of different MultiMainBlockGeometry instances
+    obtained from compacting together simliar SingleMainBlockGeometry from the
+    main_blocks multiple SingleMainBlockGeometry instances.
+
+    Parameters:
+    data (bytes): The binary data from which to extract geometry information.
+
+    Returns:
+    list: A list of compacted geometry information extracted from the data.
+
+    Raises:
+    ValueError: If the main tag cannot be found in the data, indicating that the data may not be a PDS file.
+    """
     o = 0
     main_tag, main_size = get_tag_size(data)
 
@@ -73,6 +181,26 @@ def get_geometry(data):
 def compact_geometry(
     main_blocks: Iterable[SingleMainBlockGeometry],
 ) -> Iterable[MultiMainBlockGeometry]:
+    """
+    Compacts a sequence of SingleMainBlockGeometry instances into a sequence of
+    MultiMainBlockGeometry instances.
+
+    This function takes an iterable of SingleMainBlockGeometry objects and
+    combines sequential ones that are similar enough ('compatible') into a
+    single MultiMainBlockGeometry instance. When the previous
+    SingleMainBlockGeometry instance is not compatible to the current one, a new
+    MultiMainBlockGeometry instance is started. A list of all the 
+    MultiMainBlockGeometry instances is then returned.
+
+    Args:
+        main_blocks (Iterable[SingleMainBlockGeometry]): An iterable of
+                                                         SingleMainBlockGeometry
+                                                         instances.
+
+    Yields:
+        Iterable[MultiMainBlockGeometry]: An iterable of MultiMainBlockGeometry
+                                          instances.
+    """
     base_offset = None
     prev_offset = None
     prev_distance = None
@@ -116,6 +244,32 @@ def compact_geometry(
 
 
 def extract_raw_arrays(data, mmbgs: Iterable[MultiMainBlockGeometry]):
+    """
+    Generator function to extract arrays from 'data' based on the
+    geometry given by the iterator over MultiMainBlockGeometry instances.
+
+    Iterating over a list of this generator yields a tuple for the subblocks
+    across all the MultiMainBlockGeometry instances sequentially.
+
+    Optimisation uses NumPy library as_strided function to create a view of the
+    original data array interpreted with different shape and strides. Shape will
+    have (nrows, ncols) = (mmbg.count, block.size). Stride will be 1 unless
+    mmbg.count > 1, in which case mmbg.step is used to advance to the next
+    required subblock (skipping past other subblocks with different tags)
+
+    Args:
+        data: The input data (memory map or open file) from which to extract the
+              arrays.
+        mmbgs (Iterable[MultiMainBlockGeometry]): An iterable of
+              MultiMainBlockGeometry instances.
+
+    Yields:
+        tuple: A tuple containing:
+            - mmbg.tag: The tag/signature of the main block.
+            - block.tag: The tag/signature of the subblock.
+            - ndarray: A view of the data array corresponding to the subblock,
+                       created using numpy's as_strided function.
+    """
     for mmbg in mmbgs:
         for block in mmbg.subblocks:
             yield (
@@ -174,7 +328,7 @@ def decode_srvi(rawdata):
 
 def decode_moment(name):
     def _decode(rawdata):
-        # TODO: HACK: this arbitrarily reduces the range dimension to 512 to fit with the IQ output
+        # TODO(ALL): HACK: this arbitrarily reduces the range dimension to 512 to fit with the IQ output
         return {
             name: (
                 ("frame", "range", "cocx"),
@@ -186,7 +340,7 @@ def decode_moment(name):
 
 
 def decode_iq(rawdata):
-    # TODO HACK: the 256 (for nfft) just appears, it probably should be read from somewhere else in the data
+    # TODO(ALL) HACK: the 256 (for nfft) just appears, it probably should be read from somewhere else in the data
     return {
         "FFTD": (
             ("frame", "range", "cocx", "fft", "iq"),
@@ -196,18 +350,39 @@ def decode_iq(rawdata):
 
 
 decoders = {
+    """
+    Decoders for IQ data as in Meteorological Ka-Band Cloud Radar MIRA35 Manual,
+    section 2.3.3.2 'Embedded chain type 2; Data chain'. Note these decoders are
+    specific to the HAMP radar currently in operation on HALO.
+    (last checked: 13th Septermber 2024).
+    """
     b"SRVI": decode_srvi,
     b"SNRD": decode_moment("SNRD"),
     b"VELD": decode_moment("VELD"),
     b"HNED": decode_moment("HNED"),
     b"RMSD": decode_moment("RMSD"),
-    b"FFTD": decode_iq,  # TODO HACK: FFTD may or may not be IQ data. This is configured in PPAR
+    b"FFTD": decode_iq,  # TODO(ALL) HACK: FFTD may or may not be IQ data. This is configured in PPAR
 }
 
 
 def read_iq(filename, postprocess=True):
+    """
+    Converts IQ data from a file called 'filename', into an xarray Dataset.
+
+    Optimisation uses NumPy library memory-mapped array to avoid reading
+    entirety of large binary file into main memory from disc when only (small)
+    segment is desired.
+
+    Parameters:
+    filename (str): The path to the file containing the IQ data.
+    postprocess (bool): Whether to apply post-processing to the dataset. Default is True.
+
+    Returns:
+    xarray.Dataset: The IQ data dataset.
+    """
     data = np.memmap(filename)
     raw_arrays = list(extract_raw_arrays(data, get_geometry(data)))
+    # TODO(ALL) add failure if same decoder key repeats (temporary) 
     ds = xr.Dataset(
         {
             k: v
@@ -222,19 +397,42 @@ def read_iq(filename, postprocess=True):
 
 
 def decode_time(ds):
+    """
+    Replaces 'Tm' and 'time_milli' variables in dataset 'ds' with decoded time.
+
+    The function calculates the time by adding:
+    - A base time of "1970-01-01"
+    - 'Tm' multiplied by 1 second (expressed as 1,000,000,000 ns)
+    - 'time_milli' multiplied by 0.001 (expressed as ns)
+
+    The resulting time is then assigned to a new 'time' variable in the dataset.
+
+    Parameters:
+    ds (xarray.Dataset): The input dataset containing 'Tm' and 'time_milli'
+                         variables.
+
+    Returns:
+    xarray.Dataset: The dataset with 'Tm' and 'time_milli' variables replaced by
+                    new 'time' variable added.
+    """
     time = (
         np.datetime64("1970-01-01")
         + ds.Tm * np.timedelta64(1000000000, "ns")
-        + ds.time_milli * np.timedelta64(1000, "ns")
+        + ds.time_milli * np.timedelta64(1000, "ns") # [sic] 'time_milli' is microseconds 
     )
     return ds.drop_vars(["Tm", "time_milli"]).assign(time=time)
 
 
 def postprocess_iq(ds):
+    # TODO(ALL): move to new file
     return ds.pipe(decode_time)
 
 
 def main():
+    '''
+    Use an argument parser with positional argument for the filename to read IQ
+    data from the file called 'filename' and decode the time.
+    '''
     import argparse
 
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Docstrings to aid understanding of script and relation to MIRA35 Manual.

Some docstrings are posisbly too verbose - should we reword them or put them in a documentation  e.g.  a readme instead?

PR also includes four minor changes not related to docstrings:
1) [ensure memmap of file is read only](https://github.com/halo-narval/hamp_radar/pull/2/commits/c9cc055fae5e79777b952df33f39c1959acfc8e3)
2) [refactor: explicit naming of kwarg keys](https://github.com/halo-narval/hamp_radar/pull/2/commits/12174c05178404791b3007a20f0ed366e9faa1ee)
3) [refactor: pass only bytes required by function for clarity](https://github.com/halo-narval/hamp_radar/pull/2/commits/65ef44f951c6ff05af0949280883d69c60a334a0)
4) [refactor: remove redundant list creation](https://github.com/halo-narval/hamp_radar/pull/2/commits/601a88b64c5fb12ddffb49dc50cc95c91e9e7101)