### PR TITLE
bug fix: prevent writing of mmbgs to dataset with more than one DSP configuration in data

### DIFF
--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -176,7 +176,7 @@ def get_geometry(data):
             )
             o += 8 + size
 
-    return list(compact_geometry(main_blocks(data, o)))
+    return compact_geometry(main_blocks(data, o))
 
 
 def compact_geometry(

--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -366,6 +366,44 @@ decoders = {
 }
 
 
+def single_dspparams_data(data):
+    ''' 
+    Returns raw arrays of data from the first occurrence of DSP parameters 
+    up to the next occurrence or up to the end of the data.
+    
+    The first value in the returned list of raw arrays is the DSP parameters 
+    configuration (tag == "PPAR").
+    
+    Parameters:
+    data (any): The input data (memory map or open file) from which to extract the
+                arrays associated with a single DSP parameter configuration.
+
+    Returns:
+    list: A list of raw arrays extracted from the data.
+    
+    Raises:
+    ValueError: If no PPAR tags are found in the data.
+    '''
+
+    mmbgs = get_geometry(data)
+
+    start = None
+    end = -1
+    for i, mmbg in enumerate(mmbgs):
+        if mmbg.tag == "PPAR":
+            if start is None:
+                start = i
+            else:
+                end = i
+                break
+
+    if start is None:
+        raise ValueError("No PPar tags found, data isn't associated with any DSP configuration")
+
+    single_dspparams_mmbgs = mmbgs[start:end]
+
+    return extract_raw_arrays(data, single_dspparams_mmbgs)
+
 def read_pds(filename, postprocess=True):
     """
     Converts data from a file called 'filename', into an xarray Dataset. Currently
@@ -379,9 +417,8 @@ def read_pds(filename, postprocess=True):
     Returns:
     xarray.Dataset: The IQ data dataset.
     """
-    data = np.memmap(filename, mode="r")
-    raw_arrays = extract_raw_arrays(data, get_geometry(data))
-    # TODO(ALL) add failure if same decoder key repeats (temporary)
+    data = np.memmap(filename, mode='r')
+    raw_arrays = single_dspparams_data(data)
     ds = xr.Dataset(
         {
             k: v

--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -367,14 +367,14 @@ decoders = {
 
 
 def single_dspparams_data(data):
-    ''' 
-    Returns raw arrays of data from the first occurrence of DSP parameters 
+    """
+    Returns raw arrays of data from the first occurrence of DSP parameters
     up to the next occurrence or up to the end of the data.
-    
-    The first value in the returned list of raw arrays is the DSP parameters 
+
+    The first value in the returned list of raw arrays is the DSP parameters
     configuration (tag == "PPAR").
-    
-    Raises warning if no PPiAR tags are found in the data.
+
+    Raises warning if no PPAR tags are found in the data.
 
     Parameters:
     data (any): The input data (memory map or open file) from which to extract the
@@ -382,7 +382,7 @@ def single_dspparams_data(data):
 
     Returns:
     list: A list of raw arrays extracted from the data.
-    '''
+    """
 
     mmbgs = get_geometry(data)
 
@@ -398,11 +398,14 @@ def single_dspparams_data(data):
 
     if start is None:
         start = 0
-        print("Warning: No PPar tags found, using data from entire file which isn't associated with any DSP configuration")
+        print(
+            "Warning: No PPAR tags found, using data from entire file which isn't associated with any DSP configuration"
+        )
 
     single_dspparams_mmbgs = mmbgs[start:end]
 
     return extract_raw_arrays(data, single_dspparams_mmbgs)
+
 
 def read_pds(filename, postprocess=True):
     """
@@ -417,7 +420,7 @@ def read_pds(filename, postprocess=True):
     Returns:
     xarray.Dataset: The IQ data dataset.
     """
-    data = np.memmap(filename, mode='r')
+    data = np.memmap(filename, mode="r")
     raw_arrays = single_dspparams_data(data)
     ds = xr.Dataset(
         {

--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -374,15 +374,14 @@ def single_dspparams_data(data):
     The first value in the returned list of raw arrays is the DSP parameters 
     configuration (tag == "PPAR").
     
+    Raises warning if no PPiAR tags are found in the data.
+
     Parameters:
     data (any): The input data (memory map or open file) from which to extract the
                 arrays associated with a single DSP parameter configuration.
 
     Returns:
     list: A list of raw arrays extracted from the data.
-    
-    Raises:
-    ValueError: If no PPAR tags are found in the data.
     '''
 
     mmbgs = get_geometry(data)
@@ -398,7 +397,8 @@ def single_dspparams_data(data):
                 break
 
     if start is None:
-        raise ValueError("No PPar tags found, data isn't associated with any DSP configuration")
+        start = 0
+        print("Warning: No PPar tags found, using data from entire file which isn't associated with any DSP configuration")
 
     single_dspparams_mmbgs = mmbgs[start:end]
 


### PR DESCRIPTION
PR ensure only data from start of one PPar chunk to the next one, or to end of the data, is used to make a dataset. This Fixes bug where mutliple instances of MultiMainBlockGeometry in raw_arrays would overwrite each other in a single dataset if they had matching tags.

This PR follows on from [previous PR](https://github.com/halo-narval/hamp_radar/pull/2)
