### PR TITLE
fix: end point for mmbgs slice in case of no second PPAR

### DIFF
--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -236,7 +236,7 @@ def single_dspparams_data(data):
     mmbgs = list(get_geometry(data))
 
     start = None
-    end = -1
+    end = len(mmbgs)
     for i, mmbg in enumerate(mmbgs):
         if mmbg.tag == "PPAR":
             if start is None:


### PR DESCRIPTION
In case of no second PPAR, end should be len(mmbgs) not -1 otherwise last mmbg is missed by slice.