### PR TITLE
fix: correctly identify ppar mmbg

### DIFF
--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -221,7 +221,7 @@ def single_dspparams_data(data):
     up to the next occurrence or up to the end of the data.
 
     The first value in the returned list of raw arrays is the DSP parameters
-    configuration (tag == "PPAR").
+    configuration (subblock tag == b"PPAR").
 
     Raises warning if no PPAR tags are found in the data.
 
@@ -238,7 +238,7 @@ def single_dspparams_data(data):
     start = None
     end = len(mmbgs)
     for i, mmbg in enumerate(mmbgs):
-        if mmbg.tag == "PPAR":
+        if mmbg.subblocks[0].tag == b"PPAR":
             if start is None:
                 start = i
             else:


### PR DESCRIPTION
PPAR datablocks are identified by ppar tag of subblock not mmbg itself and tag is binary sequence, ie. b"..." not "..."