### PR TITLE
refactor: get_tag_size returns correct types

### DIFF
--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -30,7 +30,7 @@ def get_tag_size(data):
                       chunk common structure'
 
     Returns:
-        Tuple[Optional[str], int]: The tag and the pointer for size. If
+        Tuple[Optional[str], int]: The tag and the pointer for size.
     """
     try:
         return bytes(data[:4]).decode("ascii"), int(data[4:8].view("<i4")[0])

--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -22,9 +22,7 @@ def get_tag_size(data):
     next 4 bytes. Bytes for tag are decoded to ascii string unless no valid
     tag can be formed (see below). Bytes for size are interpreted as an integer
 
-    If the first 4 bytes cannot be decoded as an ASCII string, (e.g. because a
-    byte in the data for the tag represents a uint not in range 0-255), then
-    UnicodeDecodeError is swallowed and tag=None and size=0 are returned.
+    If the first 4 bytes cannot be decoded as an ASCII string, tag=None and size=0 are returned.
 
     Args:
         data (bytes): The data assumed to conform with Meteorological Ka-Band

--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -229,7 +229,7 @@ def single_dspparams_data(data):
     up to the next occurrence or up to the end of the data.
 
     The first value in the returned list of raw arrays is the DSP parameters
-    configuration (subblock tag == b"PPAR").
+    configuration (subblock tag == "PPAR").
 
     Raises warning if no PPAR tags are found in the data.
 
@@ -247,7 +247,7 @@ def single_dspparams_data(data):
     start = None
     end = len(mmbgs)
     for i, mmbg in enumerate(mmbgs):
-        if mmbg.subblocks[0].tag == b"PPAR":
+        if mmbg.subblocks[0].tag == "PPAR":
             if start is None:
                 start = i
             else:

--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -17,8 +17,14 @@ def get_tag_size(data):
     Extracts the tag (also known as signature) and the pointer for size
     from 'data' assuming layout as in Meteorological Ka-Band Cloud Radar
     MIRA35 Manual, section 2.3.1 'Definition of chunk common structure'
-    where the tag is the first 4 bytes of data and the pointer is the
-    next 4 bytes.
+
+    The tag is the first 4 bytes of data and the pointer for size is the
+    next 4 bytes. Bytes for tag are decoded to ascii string unless no valid
+    tag can be formed (see below). Bytes for size are interpreted as an integer
+
+    If the first 4 bytes cannot be decoded as an ASCII string, (e.g. because a
+    byte in the data for the tag represents a uint not in range 0-255), then
+    UnicodeDecodeError is swallowed and tag=None and size=0 are returned.
 
     Args:
         data (bytes): The data assumed to conform with Meteorological Ka-Band
@@ -26,7 +32,7 @@ def get_tag_size(data):
                       chunk common structure'
 
     Returns:
-        Tuple[bytes, int]: The tag and the pointer for size.
+        Tuple[Optional[str], int]: The tag and the pointer for size. If
     """
     try:
         return bytes(data[:4]).decode("ascii"), int(data[4:8].view("<i4")[0])

--- a/hamp_radar/iquick.py
+++ b/hamp_radar/iquick.py
@@ -51,8 +51,7 @@ def main_ofs(mainblock):
     o = 0
     ofs = []
     while o + 8 < len(mainblock):
-        blocktype = bytes(mainblock[o : o + 4]).decode("ascii")
-        blocksize = int(mainblock[o + 4 : o + 8].view("<i4")[0])
+        blocktype, blocksize = get_tag_size(mainblock[o : o + 8])
         ofs.append(SingleSubBlockGeometry(blocktype, o + 8, blocksize))
         o += 8 + blocksize
     return ofs


### PR DESCRIPTION
This is a preliminary step required for making a flight dataset from multiple .pds files (see 3 upcomming PRs :) )

- required because json cannot store bytes without encoding, but simple ascii or utf-8 encoding breaks with current methods for reading geometries
- first 4 bytes of data given to `get_tag_size` function are now decoded to ascii string. If this is not possible no valid tag can be formed (e.g, because a byte in the tag slice of the data represents a uint not in range 0-255) tag=None and size=0 are returned instead.
- the ascii encoded tag is then compatible with writing to jsons so that serde can be used on geometry classes