### PR TITLE
minor cleaning-up code refactoring

### DIFF
--- a/hamp_radar/decoders.py
+++ b/hamp_radar/decoders.py
@@ -1,4 +1,3 @@
-import numpy as np
 import xarray as xr
 from typing import Optional
 
@@ -211,24 +210,3 @@ decoders = {
     "RMSD": decode_moment("RMSD"),
     "FFTD": decode_fftd,
 }
-
-
-def decode_time(ds):
-    """
-    Replaces 'Tm' and 'time_milli' variables in dataset 'ds' with decoded time.
-
-    Parameters:
-    ds (xarray.Dataset): The input dataset containing 'Tm' and 'time_milli'
-                         variables.
-
-    Returns:
-    xarray.Dataset: The dataset with 'Tm' and 'time_milli' variables replaced by
-                    new 'time' variable added.
-    """
-    time = (
-        np.datetime64("1970-01-01")
-        + ds.Tm * np.timedelta64(1000000000, "ns")
-        + ds.time_milli
-        * np.timedelta64(1000, "ns")  # [sic] 'time_milli' is microseconds
-    )
-    return ds.drop_vars(["Tm", "time_milli"]).assign(time=time)

--- a/hamp_radar/flight_dataset.py
+++ b/hamp_radar/flight_dataset.py
@@ -29,11 +29,20 @@ def read_datasetblock(
 
 
 def read_dataset(dsgeom: DatasetGeometry, postprocess: bool):
+    import warnings
+
     ds_ppar = read_datasetblock(dsgeom.ppar)
 
     dataset = [read_datasetblock(d, ds_ppar).chunk("auto") for d in dsgeom.data]
-    dataset = xr.concat(dataset, dim="frame")
-    dataset = dataset.merge(ds_ppar)
+    if dataset != []:
+        dataset = xr.concat(dataset, dim="frame")
+        dataset = dataset.merge(ds_ppar)
+    else:
+        warnings.warn(
+            "Warning: no data blocks in dataset",
+            UserWarning,
+        )
+        dataset = ds_ppar
 
     dataset = dataset.assign_attrs(radar_tag=dsgeom.ppar.mainblock.tag)
 

--- a/hamp_radar/flight_dataset.py
+++ b/hamp_radar/flight_dataset.py
@@ -5,15 +5,10 @@ import xarray as xr
 import numpy as np
 
 from iquick import extract_raw_arrays
-from decoders import decode_time, pds_decode
+from decoders import pds_decode
 from geometries import FlightGeometry, DatasetGeometry
-
+from postprocess import postprocess_iq
 from serde_flight import get_flight_geometry
-
-
-def postprocess_iq(ds):
-    # TODO(ALL): move to new file
-    return ds.pipe(decode_time)
 
 
 def read_datasetblock(

--- a/hamp_radar/postprocess.py
+++ b/hamp_radar/postprocess.py
@@ -1,0 +1,27 @@
+import numpy as np
+import xarray as xr
+
+
+def postprocess_iq(ds: xr.Dataset):
+    return ds.pipe(postprocess_time)
+
+
+def postprocess_time(ds):
+    """
+    Replaces 'Tm' and 'time_milli' variables in dataset 'ds' with decoded time.
+
+    Parameters:
+    ds (xarray.Dataset): The input dataset containing 'Tm' and 'time_milli'
+                         variables.
+
+    Returns:
+    xarray.Dataset: The dataset with 'Tm' and 'time_milli' variables replaced by
+                    new 'time' variable added.
+    """
+    time = (
+        np.datetime64("1970-01-01")
+        + ds.Tm * np.timedelta64(1000000000, "ns")
+        + ds.time_milli
+        * np.timedelta64(1000, "ns")  # [sic] 'time_milli' is microseconds
+    )
+    return ds.drop_vars(["Tm", "time_milli"]).assign(time=time)

--- a/hamp_radar/serde_pds_files.py
+++ b/hamp_radar/serde_pds_files.py
@@ -8,6 +8,7 @@ from iquick import get_geometry
 
 
 def scan_pdsfile(filename: Path):
+    assert filename.suffix == ".pds", "is this a pds file?"
     data = np.memmap(filename, mode="r")
     mmbgs = list(get_geometry(data))
     return PdsFileGeometry(filename, mmbgs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ numpy = "*"
 xarray = "*"
 pyserde = "*"
 orjson = "*"
+more_itertools = "*"
 
 [tool.poetry.group.test.dependencies]
 pytest = "*"


### PR DESCRIPTION
keeps functionality the same but:
- improve convert_to_datasetgeometries to be clearer and only create valid instances
- move post processing to separate file (in preperation for when we add more post-process functions to this file)
- made it possible for "flights" with only a ppar and no data to be handled without error and with added warning instead