### PR TITLE
write flight datasets to zarr files

### DIFF
--- a/hamp_radar/iquick_datasets.py
+++ b/hamp_radar/iquick_datasets.py
@@ -98,7 +98,9 @@ def read_dataset(
     return dataset
 
 
-def read_collection(geom: CollectionGeometry, postprocess=True) -> Iterable[xr.Dataset]:
+def read_collection(
+    geom: CollectionGeometry, postprocess=True, use_autochunks: bool = False
+) -> Iterable[xr.Dataset]:
     """
     Converts data from .pds files accorinding to the CollectionGeometry,
     into several xarray datasets (one for each DSP configuration). Currently
@@ -113,7 +115,9 @@ def read_collection(geom: CollectionGeometry, postprocess=True) -> Iterable[xr.D
        Iterable[xarray.Dataset]: iterable to the next IQ data dataset in the collection.
     """
     for dsgeom in geom.datasets:
-        yield read_dataset(dsgeom, postprocess).assign_attrs(name=geom.name)
+        yield read_dataset(
+            dsgeom, postprocess, use_autochunks=use_autochunks
+        ).assign_attrs(name=geom.name)
 
 
 def main():
@@ -171,15 +175,13 @@ def main():
         is_pdsjsons=args.is_pdsjsons,
     )
 
-    flight_datasets = read_collection(geom)
-
     if args.writedir:
-        for i, ds in enumerate(flight_datasets):
+        for i, ds in enumerate(read_collection(geom)):
             filename = args.writedir / f"{ds.name}_{i}.zarr"
             print(f"writing {filename}")
             write_iqdataset(ds, filename)
     else:
-        for ds in flight_datasets:
+        for ds in read_collection(geom, use_autochunks=True):
             print(ds)
 
 

--- a/hamp_radar/iquick_datasets.py
+++ b/hamp_radar/iquick_datasets.py
@@ -33,7 +33,13 @@ def read_dataset(dsgeom: DatasetGeometry, postprocess: bool):
 
     ds_ppar = read_datasetblock(dsgeom.ppar)
 
-    dataset = [read_datasetblock(d, ds_ppar).chunk("auto") for d in dsgeom.data]
+    chunks = {
+        "cocx": 2,
+        "range": 512,  # TODO(ALL): see HACK about range dimension = 512
+        "fft": 256,
+        "iq": 2,
+    }
+    dataset = [read_datasetblock(d, ds_ppar).chunk(chunks) for d in dsgeom.data]
     if dataset != []:
         dataset = xr.concat(dataset, dim="frame")
         dataset = dataset.merge(ds_ppar)

--- a/hamp_radar/iquick_datasets.py
+++ b/hamp_radar/iquick_datasets.py
@@ -108,6 +108,13 @@ def main():
         help="True = filenames is for serialized flight .json",
         type=bool,
     )
+    parser.add_argument(
+        "-w",
+        "--writedir",
+        default=None,
+        help="True = directory for writing flight datasets",
+        type=Path,
+    )
     args = parser.parse_args()
 
     if args.is_flightjson:
@@ -123,9 +130,17 @@ def main():
         is_collectionjson=args.is_flightjson,
         is_pdsjsons=args.is_pdsjsons,
     )
+
     flight_datasets = read_collection(geom)
-    for ds in flight_datasets:
-        print(ds)
+
+    if args.writedir:
+        for i, ds in enumerate(flight_datasets):
+            filename = args.writedir / f"{ds.name}_{i}.zarr"
+            print(f"writing {filename}")
+            ds.to_zarr(f"{filename}")
+    else:
+        for ds in flight_datasets:
+            print(ds)
 
 
 if __name__ == "__main__":

--- a/hamp_radar/iquick_datasets.py
+++ b/hamp_radar/iquick_datasets.py
@@ -9,6 +9,7 @@ from decoders import pds_decode
 from geometries import CollectionGeometry, DatasetGeometry
 from postprocess import postprocess_iq
 from serde_collection import get_collection_geometry
+from writezarr import write_iqdataset
 
 
 def read_datasetblock(
@@ -38,6 +39,7 @@ def read_dataset(dsgeom: DatasetGeometry, postprocess: bool):
         "range": 512,  # TODO(ALL): see HACK about range dimension = 512
         "fft": 256,
         "iq": 2,
+        "frame": 128,  # TODO(ALL): HACK makes iq dask array chunks circa. 100MB
     }
     dataset = [read_datasetblock(d, ds_ppar).chunk(chunks) for d in dsgeom.data]
     if dataset != []:
@@ -137,7 +139,7 @@ def main():
         for i, ds in enumerate(flight_datasets):
             filename = args.writedir / f"{ds.name}_{i}.zarr"
             print(f"writing {filename}")
-            ds.to_zarr(f"{filename}")
+            write_iqdataset(ds, filename)
     else:
         for ds in flight_datasets:
             print(ds)

--- a/hamp_radar/writezarr.py
+++ b/hamp_radar/writezarr.py
@@ -1,0 +1,52 @@
+import xarray as xr
+from pathlib import Path
+
+
+def ideal_zarrchunks(ds: xr.Dataset):
+    """returns ideal size of chunks for variables with these dimensions
+    so that chuunks are about 1MB. Addiontally cocx dimension (size=2)
+    is split into 2 seperate chunks and range dimension (size=512)
+    is sub-divided into 16 smaller chunks (size=32)"""
+    import warnings
+
+    frame = ds.sizes["frame"]
+    if frame > 2621440:
+        warnings.warn(
+            "Warning: number of frames is very large, consider changing ideal chunkshapes",
+            UserWarning,
+        )
+    return {
+        (): (),
+        ("frame",): (frame,),
+        ("frame", "cocx"): (frame, 1),
+        ("frame", "range", "cocx"): (8192, 32, 1),
+        ("frame", "range", "cocx", "fft", "iq"): (512, 32, 1, 256, 2),
+    }
+
+
+def zarr_encoding(ds: xr.Dataset):
+    ideal_chunks = ideal_zarrchunks(ds)
+    encoding = {
+        x: {"chunks": ideal_chunks[ds[x].dims]}
+        for x in list(ds.coords) + list(ds.data_vars)
+        if ds[x].chunks
+    }
+    return encoding
+
+
+def prepare_daskarrays_for_zarrchunks(ds: xr.Dataset, encoding: dict):
+    def safe_chunks(current_chunks, desired_chunks):
+        return [max(i, c) for i, c in zip(current_chunks, desired_chunks)]
+
+    for x in list(ds.coords) + list(ds.data_vars):
+        if ds[x].chunks:
+            current_chunks = (c[0] for c in ds[x].chunks)
+            desired_chunks = encoding[x]["chunks"]
+            ds[x] = ds[x].chunk(safe_chunks(current_chunks, desired_chunks))
+    return ds
+
+
+def write_iqdataset(ds: xr.Dataset, filename: Path):
+    encoding = zarr_encoding(ds)
+    ds = prepare_daskarrays_for_zarrchunks(ds, encoding)
+    ds.to_zarr(filename, encoding=encoding)

--- a/hamp_radar/writezarr.py
+++ b/hamp_radar/writezarr.py
@@ -3,34 +3,59 @@ from pathlib import Path
 from typing import Optional
 
 
-def ideal_zarrchunks(ds: xr.Dataset):
-    """returns ideal size of chunks for variables with these dimensions
-    so that chuunks are about 1MB. Addiontally cocx dimension (size=2)
-    is split into 2 seperate chunks and range dimension (size=512)
-    is sub-divided into 16 smaller chunks (size=32)"""
+"""chunks for arrays with these dimensions such that chunksizes
+are about 250MB, e.g. each chunk contains 65536000 4 byte integers,
+(ideal for dask arrays) and such that dask chunk lengths along
+each dimension are >= length of ideal_zarrchunks"""
+ideal_daskchunks = {
+    (): ({}),
+    ("frame",): {
+        "frame": 65536000,
+    },
+    ("frame", "cocx"): {
+        "frame": 32768000,
+        "cocx": 2,
+    },
+    ("frame", "range", "cocx"): {
+        "frame": 512000,
+        "range": 64,
+        "cocx": 2,
+    },
+    ("frame", "range", "cocx", "fft", "iq"): {
+        "frame": 2048,
+        "range": 64,
+        "cocx": 2,
+        "fft": 256,
+        "iq": 2,
+    },
+}
+
+
+def ideal_zarrchunks(nframe: int):
+    """returns ideal chunks for zarr for arrays with these dimensions such that
+    chunksizes are about 10MB, e.g. a chunk contains 2621440 4 byte integers,
+    and such that cocx dimension (size=2) is split into 2 seperate chunks and
+    range dimension (size=512) is sub-divided into smaller chunks (size=32)"""
     import warnings
 
-    frame = ds.sizes["frame"]
-    if frame > 2621440:
+    if nframe > 2621440:
         warnings.warn(
             "Warning: number of frames is very large, consider changing ideal chunkshapes",
             UserWarning,
         )
     return {
         (): (),
-        ("frame",): (frame,),
-        ("frame", "cocx"): (frame, 1),
-        ("frame", "range", "cocx"): (8192, 32, 1),
+        ("frame",): (nframe,),
+        ("frame", "cocx"): (nframe, 1),
+        ("frame", "range", "cocx"): (81920, 32, 1),
         ("frame", "range", "cocx", "fft", "iq"): (512, 32, 1, 256, 2),
     }
 
 
-def zarr_chunks_encoding(ds: xr.Dataset):
-    ideal_chunks = ideal_zarrchunks(ds)
+def ideal_zarrchunks_encoding(ds: xr.Dataset):
+    chunks = ideal_zarrchunks(ds.sizes["frame"])
     encoding = {
-        x: {"chunks": ideal_chunks[ds[x].dims]}
-        for x in list(ds.coords) + list(ds.data_vars)
-        if ds[x].chunks
+        x: {"chunks": chunks[ds[x].dims]} for x in list(ds.coords) + list(ds.data_vars)
     }
     return encoding
 
@@ -49,24 +74,11 @@ def merge_encodings(e1: dict, e2: dict):
 
 def zarr_encoding(ds: xr.Dataset, encoding: Optional[dict] = None):
     if encoding is None:
-        return zarr_chunks_encoding(ds)
+        return ideal_zarrchunks_encoding(ds)
     else:
-        return merge_encodings(encoding, zarr_chunks_encoding(ds))
-
-
-def prepare_daskarrays_for_zarrchunks(ds: xr.Dataset, encoding: dict):
-    def safe_chunks(current_chunks, desired_chunks):
-        return [max(i, c) for i, c in zip(current_chunks, desired_chunks)]
-
-    for x in list(ds.coords) + list(ds.data_vars):
-        if ds[x].chunks:
-            current_chunks = (c[0] for c in ds[x].chunks)
-            desired_chunks = encoding[x]["chunks"]
-            ds[x] = ds[x].chunk(safe_chunks(current_chunks, desired_chunks))
-    return ds
+        return merge_encodings(encoding, ideal_zarrchunks_encoding(ds))
 
 
 def write_iqdataset(ds: xr.Dataset, filename: Path):
     encoding = zarr_encoding(ds)
-    ds = prepare_daskarrays_for_zarrchunks(ds, encoding)
     ds.to_zarr(filename, encoding=encoding)

--- a/hamp_radar/writezarr.py
+++ b/hamp_radar/writezarr.py
@@ -17,7 +17,7 @@ ideal_daskchunks = {
         "cocx": 2,
     },
     ("frame", "range", "cocx"): {
-        "frame": 512000,
+        "frame": 491520,
         "range": 64,
         "cocx": 2,
     },


### PR DESCRIPTION
- hardcodes chunk sizes of datasets to be more optimal considering the typical lengths of the dimensions of `cocx, range, fft` and `iq`. Fixed chunk sizes also makes it possible to write the dataset(s) to .zarr files (`chunks="auto"` makes the chunk sizes irregular)
- add option to write datasets from a flight using the flightname given the directory where they should be written (do we want this?)