### PR TITLE
refactor: generalise word "flight"

### DIFF
--- a/hamp_radar/geometries.py
+++ b/hamp_radar/geometries.py
@@ -129,14 +129,16 @@ class DatasetGeometry:
 
 
 @dataclass
-class FlightGeometry:
+class CollectionGeometry:
     """
-    Representation of a flight is the name of the flight combined with the
-    geometries for the series of datasets that compose that flight.
+    Representation of a collection is the name of the collection and a series of
+    geometries for datasets within the collection.
+
+    Useful e.g. for a collection of datasets from a single flight with name="flightname"
 
     Attributes:
-        name (str): name of the flith
-        datasets (List[DatasetGeometry]): list of geometries for the datasets of the flight.
+        name (str): name of the collection
+        datasets (List[DatasetGeometry]): list of geometries for the datasets in the collection.
     """
 
     name: str

--- a/hamp_radar/iquick_datasets.py
+++ b/hamp_radar/iquick_datasets.py
@@ -6,9 +6,9 @@ import numpy as np
 
 from iquick import extract_raw_arrays
 from decoders import pds_decode
-from geometries import FlightGeometry, DatasetGeometry
+from geometries import CollectionGeometry, DatasetGeometry
 from postprocess import postprocess_iq
-from serde_flight import get_flight_geometry
+from serde_collection import get_collection_geometry
 
 
 def read_datasetblock(
@@ -52,28 +52,28 @@ def read_dataset(dsgeom: DatasetGeometry, postprocess: bool):
     return dataset
 
 
-def read_flight(flightgeom: FlightGeometry, postprocess=True) -> Iterable[xr.Dataset]:
+def read_collection(geom: CollectionGeometry, postprocess=True) -> Iterable[xr.Dataset]:
     """
-    Converts data from .pds files accorinding to the flightgeometry,
+    Converts data from .pds files accorinding to the CollectionGeometry,
     into several xarray datasets (one for each DSP configuration). Currently
     only functioning with geometry of pds files and decoders for IQ data of
     Ka radar currently operational on HALO (last checked: 13th Septermber 2024).
 
     Parameters:
-        flightgeometry (FlightGeometry): The flight geometry of the flight.
+        geom (CollectionGeometry): The geometry of the collection of datasets, e.g. for a flight.
         postprocess (bool): Whether to apply post-processing to the dataset. Default is True.
 
     Returns:
-       Iterable[xarray.Dataset]: iterable to the next IQ data dataset in the flight.
+       Iterable[xarray.Dataset]: iterable to the next IQ data dataset in the collection.
     """
-    for dsgeom in flightgeom.datasets:
-        yield read_dataset(dsgeom, postprocess).assign_attrs(flightname=flightgeom.name)
+    for dsgeom in geom.datasets:
+        yield read_dataset(dsgeom, postprocess).assign_attrs(name=geom.name)
 
 
 def main():
     """
     e.g.
-    python flight_dataset.py ./bin/jsons/HALO-20240818a-test.json
+    python iquick_datasets.py ./bin/jsons/HALO-20240818a-test.json
     """
     import argparse
 
@@ -111,13 +111,13 @@ def main():
     else:
         filenames = args.filenames
 
-    geom = get_flight_geometry(
+    geom = get_collection_geometry(
         filenames,
-        flightname=args.flightname,
-        is_flightjson=args.is_flightjson,
+        collectionname=args.flightname,
+        is_collectionjson=args.is_flightjson,
         is_pdsjsons=args.is_pdsjsons,
     )
-    flight_datasets = read_flight(geom)
+    flight_datasets = read_collection(geom)
     for ds in flight_datasets:
         print(ds)
 

--- a/hamp_radar/serde_collection.py
+++ b/hamp_radar/serde_collection.py
@@ -7,7 +7,7 @@ from geometries import (
     PdsFileGeometry,
     DatasetBlockGeometry,
     DatasetGeometry,
-    FlightGeometry,
+    CollectionGeometry,
 )
 from serde_pds_files import (
     get_pdsfile_geometries,
@@ -162,12 +162,12 @@ def convert_to_datasetgeometries(
         yield DatasetGeometry(ppar, data)
 
 
-def scan_flight(flightname: str, pfgs: Iterable[PdsFileGeometry]):
+def scan_collection(name: str, pfgs: Iterable[PdsFileGeometry]):
     datasets = list(convert_to_datasetgeometries(pfgs))
-    return FlightGeometry(flightname, datasets)
+    return CollectionGeometry(name, datasets)
 
 
-def write_flight_geometry(geom: FlightGeometry, geomsdir: Path):
+def write_collection_geometry(geom: CollectionGeometry, geomsdir: Path):
     import time
 
     start = time.time()
@@ -179,27 +179,27 @@ def write_flight_geometry(geom: FlightGeometry, geomsdir: Path):
     print(f"serializing {geom.name}: {end - start:.5f}s")
 
 
-def get_flight_geometry(
+def get_collection_geometry(
     filenames: Union[Path, List[Path]],
-    flightname: Optional[str] = None,
-    is_flightjson=False,
+    collectionname: Optional[str] = None,
+    is_collectionjson=False,
     is_pdsjsons=False,
-) -> FlightGeometry:
-    if is_flightjson:
-        return deserialize_data(filenames, FlightGeometry)
+) -> CollectionGeometry:
+    if is_collectionjson:
+        return deserialize_data(filenames, CollectionGeometry)
     else:
-        if flightname is None:
-            raise ValueError("please provide a flightname for the flight geometry")
+        if collectionname is None:
+            raise ValueError("please provide a name for the collection")
         pfgs = get_pdsfile_geometries(filenames, is_jsons=is_pdsjsons)
-        return scan_flight(flightname, pfgs)
+        return scan_collection(collectionname, pfgs)
 
 
 def main():
     """
     e.g.
-    python serde_flight.py -g dummy_flight_jsons dummy_flight_pds/*.pds --flightname dummyflight100
+    python serde_collection.py -g dummy_flight_jsons dummy_flight_pds/*.pds --flightname dummyflight100
     or
-    python serde_flight.py -g dummy_flight_jsons dummy_flight_pds/*.jsons --flightname dummyflight100 --is_jsons True
+    python serde_collection.py -g dummy_flight_jsons dummy_flight_pds/*.jsons --flightname dummyflight100 --is_jsons True
     """
     import argparse
 
@@ -224,8 +224,8 @@ def main():
     args = parser.parse_args()
 
     pfgs = get_pdsfile_geometries(args.filenames, is_jsons=args.is_jsons)
-    geom = scan_flight(args.flightname, pfgs)
-    write_flight_geometry(geom, args.geomsdir)
+    geom = scan_collection(args.flightname, pfgs)
+    write_collection_geometry(geom, args.geomsdir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Issue:
- Use of "flight" to describe a group of datasets with a name isn't really appropriate, e.g. `FlightGeometry` is actually much more general than a flight would be.

Solution:
- Instead of "flight" in things like `FlightGeometry` I think "collection" is a better word.  It better describes what these things actually are, i.e. it better describes a group of datasets with a name.